### PR TITLE
vendored feature fix and dependency cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ fs_extra = {version = "1.3.0", optional = true}
 pkg-config = "0.3.30" # XXX - this should be optional but we can't.
 
 [features]
-default = ["approx", "vendored"]
+default = ["approx"]
 vendored = ["autotools", "fs_extra"]
 approx = []
 wchar = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,3 @@ default = ["approx"]
 vendored = ["autotools", "fs_extra"]
 approx = []
 wchar = []
-
-[dependencies]
-autotools = "0.2"
-bindgen = "0.71.1"
-pkg-config = "0.3.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["external-ffi-bindings", "text-processing"]
 keywords = ["regex", "tre", "ffi", "bindings", "sys"]
 
 [build-dependencies]
-bindgen = "0.71.1"
+bindgen = {version = "0.71.1", default-features = false, features = []}
 autotools = {version = "0.2", optional = true}
 fs_extra = {version = "1.3.0", optional = true}
 pkg-config = "0.3.30" # XXX - this should be optional but we can't.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Feature flags
 The following features are available:
 
 - `approx`: Enable approximate matching functionality (enabled by default)
-- `vendored`: Enable vendored build copy of TRE instead of system TRE (enabled by default)
+- `vendored`: Enable vendored build copy of TRE instead of system TRE (disabled by default)
 - `wchar`: Enable functions designed to work with `wchar_t` (disabled by default)
 
 Supported versions


### PR DESCRIPTION
resolves #2 

tested [here](https://git.poz.pet/poz/szablon/commit/6e778bd38bb0f737f29fbd47283d53820a270d77), builds fine with `tre` from nixpkgs